### PR TITLE
NOCARD Add RollBarWriter typeclass

### DIFF
--- a/rollbar.cabal
+++ b/rollbar.cabal
@@ -18,11 +18,13 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
+  default-extensions:  NamedFieldPuns, TupleSections, FlexibleContexts, ConstraintKinds, TypeSynonymInstances, FlexibleInstances,
+                       ViewPatterns, UndecidableInstances, MultiParamTypeClasses, OverloadedStrings, TemplateHaskell, LambdaCase
   hs-source-dirs:      src
   exposed-modules:     Web.Rollbar
                      , Web.Rollbar.Internal
                      , Web.Rollbar.Types
-
+                     , Web.Rollbar.Class
   build-depends:       base
                      , aeson
                      , containers

--- a/src/Web/Rollbar.hs
+++ b/src/Web/Rollbar.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Web.Rollbar
     ( -- * Reporting function
       rollbar

--- a/src/Web/Rollbar/Class.hs
+++ b/src/Web/Rollbar/Class.hs
@@ -1,0 +1,25 @@
+module Web.Rollbar.Class
+    ( MonadRollbarWriter(..)
+    ) where
+
+import qualified Web.Rollbar as R
+import Control.Monad.Except (MonadError)
+import Control.Monad.Reader (MonadReader)
+import Control.Monad.Trans (MonadIO)
+import Network.HTTP.Nano
+    ( AsHttpError
+    , HasHttpCfg
+    )
+
+class MonadRollbarWriter m where
+    rollbar :: (R.ToRollbarEvent evt) => evt -> m ()
+
+instance 
+    ( MonadIO m
+    , MonadError e m
+    , MonadReader r m
+    , AsHttpError e
+    , HasHttpCfg r
+    , R.HasRollbarCfg r
+    ) => MonadRollbarWriter m where
+    rollbar = R.rollbar

--- a/src/Web/Rollbar/Internal.hs
+++ b/src/Web/Rollbar/Internal.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Web.Rollbar.Internal where
 
 import Control.Lens ((^.), view)

--- a/src/Web/Rollbar/Types.hs
+++ b/src/Web/Rollbar/Types.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module Web.Rollbar.Types
     ( -- * Configuration
       RollbarCfg(..)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.10
+resolver: lts-12.10
 packages:
 - '.'
 - location:


### PR DESCRIPTION
I added a new typeclass `MonadRollbarWriter` and instance that should work with our vines as a drop in replacement for the top-level `rollbar` function.  It should allow us to test functions that use Rollbar a bit easier.

I also bumped the LTS version to match our vines version.